### PR TITLE
Ignore number:fill-character

### DIFF
--- a/lib/Spreadsheet/ParseODS/Styles.pm
+++ b/lib/Spreadsheet/ParseODS/Styles.pm
@@ -120,6 +120,8 @@ sub part_to_format( $self, $part ) {
         # ignored
     } elsif( $t eq 'loext:fill-character' ) {
         # ignored
+    } elsif( $t eq 'number:fill-character' ) {
+        # ignored
     } elsif( $t eq 'style:map' ) {
         # ignored
     } elsif( $t eq '#PCDATA' ) {


### PR DESCRIPTION
That causes truckloads of warnings. Ignored because the other
fill-character is also ignored.

using libreoffice-calc-7.0.0.0.beta2-3.1.x86_64

Maybe you want

 } elsif ($t =~ m{^(\w+):fill-character$}) {
     # ignored: number, loext

Signed-off-by: H.Merijn Brand - Tux <h.m.brand@xs4all.nl>