### PR TITLE
OrderBySheet

### DIFF
--- a/lib/Spreadsheet/ReadSXC.pm
+++ b/lib/Spreadsheet/ReadSXC.pm
@@ -118,7 +118,7 @@ sub _parse_xml {
     };
 
     if ( $options_ref->{OrderBySheet} ) {
-        return [ map { $res->{ $_ } } $workbook->worksheets ]
+        return [ map { $res->{ $_->{label} } } $workbook->worksheets ]
     } else {
         return $res
     }


### PR DESCRIPTION
    #!/usr/bin/env perl
    use strict;
    use warnings;
    use Spreadsheet::ReadSXC qw(read_sxc);
    use Data::Dumper;
    my $file = "./MyTest.ods";


    my $book_h_ref = read_sxc( $file );
    print Dumper [ map { $book_h_ref->{$_} } sort keys %$book_h_ref ];
    # Output:
    # $VAR1 = [ [ [ 'a1', 'b1' ], [ 'a2', 'b2' ] ], [ [ 'A1', 'B1' ], [ 'A2', 'B2' ] ] ];


    my $book_a_ref = read_sxc( $file, { OrderBySheet => 1 } );
    print Dumper $book_a_ref;
    # Output original:
    # $VAR1 = [ undef, undef ];
    # Output with applied patch:
    # $VAR1 = [ [ [ 'a1', 'b1' ], [ 'a2', 'b2' ] ], [ [ 'A1', 'B1' ], [ 'A2', 'B2' ] ] ];
